### PR TITLE
Suppress empty recipient fields

### DIFF
--- a/src/email.rs
+++ b/src/email.rs
@@ -74,11 +74,13 @@ impl Message {
     }
 
     fn add_recipients(field: &str, addresses: Vec<EmailAddress>, params: &mut HashMap<String, String>) {
-        let joined = addresses.iter()
-            .map(EmailAddress::to_string)
-            .collect::<Vec<String>>()
-            .join(",");
-        params.insert(field.to_owned(), joined);
+        if !addresses.is_empty() {
+            let joined = addresses.iter()
+                .map(EmailAddress::to_string)
+                .collect::<Vec<String>>()
+                .join(",");
+            params.insert(field.to_owned(), joined);
+        }
     }
 }
 


### PR DESCRIPTION
Mailgun will reject (HTTP code 400) requests to send messages that
contains an empty cc or bcc field.
Don't add the field(s) if they don't contain any recipients.