### PR TITLE
Allow to send messages using a custom API endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,6 @@ reqwest = { version = "^0.10.1", features = ["json", "blocking"] }
 serde = "^1.0.71"
 serde_derive = "^1.0.71"
 serde_json = "^1.0.24"
+
+[dev-dependencies]
+mockito = "^0.23.1"

--- a/src/email.rs
+++ b/src/email.rs
@@ -120,11 +120,18 @@ pub fn send_email(creds: &Credentials, sender: &EmailAddress, msg: Message) ->  
 
 /// Same as `send_email` but with an externally managed client
 pub fn send_with_client(client: &reqwest::blocking::Client, creds: &Credentials, sender: &EmailAddress, msg: Message) -> MailgunResult<SendResponse> {
+    let url = format!("{}/{}/{}", MAILGUN_API, creds.domain, MESSAGES_ENDPOINT);
+    let request_builder = client.post(&url);
+    send_with_request_builder(request_builder, creds, sender, msg)
+}
+
+/// Same as `send_email` but with an externally managed request builder.
+/// Use this in case you want to send the mails to a custom API endpoint, e.g. for testing.
+pub fn send_with_request_builder(request_builder: reqwest::blocking::RequestBuilder, creds: &Credentials, sender: &EmailAddress, msg: Message) -> MailgunResult<SendResponse> {
     let mut params = msg.to_params();
     params.insert("from".to_string(), sender.to_string());
-    let url = format!("{}/{}/{}", MAILGUN_API, creds.domain, MESSAGES_ENDPOINT);
 
-    let res = client.post(&url)
+    let res = request_builder
         .basic_auth("api", Some(creds.api_key.clone()))
         .form(&params)
         .send()?
@@ -138,6 +145,7 @@ pub fn send_with_client(client: &reqwest::blocking::Client, creds: &Credentials,
 mod tests {
     use reqwest::StatusCode;
     use super::*;
+    use serde_json::json;
 
     #[test]
     fn message_body() {
@@ -234,6 +242,42 @@ mod tests {
         let sender = EmailAddress::name_address("Nick Testla", &format!("mailgun_v3@{}", &domain));
 
         let res = send_email(&creds, &sender, message);
+        assert!(res.is_ok(), format!("{:?}", &res));
+    }
+
+    #[test]
+    fn test_send_with_request_builder() {
+        let domain = "sandbox0123456789abcdef0123456789abcdef.mailgun.org";
+        let key = "0123456789abcdef0123456789abcdef-01234567-89abcdef";
+        let recipient = "user@example.com";
+
+        let creds = Credentials::new(&key, &domain);
+        let recipient = EmailAddress::address(&recipient);
+        let message = Message {
+            to: vec![recipient],
+            subject: "Test email".to_string(),
+            body: MessageBody::Text(String::from("This email is from an mailgun_v3 automated test")),
+            ..Default::default()
+        };
+        let sender = EmailAddress::name_address("Nick Testla", &format!("mailgun_v3@{}", &domain));
+
+        let domain = &mockito::server_url();
+        let uri = format!("/{}/{}", creds.domain, MESSAGES_ENDPOINT);
+
+        let response = json!({
+            "id": "<0123456789abcdef.0123456789abcdef@sandbox0123456789abcdef0123456789abcdef.mailgun.org>",
+            "message": "Queued. Thank you."
+        });
+        let _m = mockito::mock("POST", uri.as_str())
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(response.to_string())
+            .create();
+
+        let url = format!("{}{}", domain, uri);
+        let client = reqwest::blocking::Client::new();
+        let request_builder = client.post(&url);
+        let res = send_with_request_builder(request_builder, &creds, &sender, message);
         assert!(res.is_ok(), format!("{:?}", &res));
     }
 }


### PR DESCRIPTION
Fixes #4 

In order to retain backwards compatibility I have introduced a new function `send_with_request_builder()` that can be passed a `RequestBuilder` struct which is instantiated with a custom request URL.

A unit test is demonstrating how this can be used for in the test suite of an implementing project, using a mocked API endpoint provided by mockito.